### PR TITLE
Improve playback toggles and menu bar integration

### DIFF
--- a/MacroRecorder/MacroRecorder/MainView.swift
+++ b/MacroRecorder/MacroRecorder/MainView.swift
@@ -114,13 +114,14 @@ struct MainView: View {
                 }
                 .buttonStyle(SubtleButtonStyle())
                 .disabled(selectedMacro == nil || recorder.isRecording || recorder.isReplaying)
-                .keyboardShortcut(.init(.p), modifiers: [.command, .option])
 
-                Button(action: replayer.replayMostRecentMacro) {
-                    Label("Replay Latest", systemImage: "gobackward")
+                Button(action: replayer.togglePlayback) {
+                    Label(replayer.isReplaying ? "Stop Playback" : "Replay Latest",
+                          systemImage: replayer.isReplaying ? "stop.circle" : "gobackward")
                 }
-                .buttonStyle(SubtleButtonStyle())
-                .disabled(macroManager.mostRecentMacro == nil || recorder.isRecording || recorder.isReplaying)
+                .buttonStyle(SubtleButtonStyle(isDestructive: replayer.isReplaying))
+                .disabled((macroManager.mostRecentMacro == nil && !replayer.isReplaying) || recorder.isRecording)
+                .keyboardShortcut(.init(.p), modifiers: [.command, .option])
             }
 
             Divider()

--- a/MacroRecorder/MacroRecorder/MenuBar.swift
+++ b/MacroRecorder/MacroRecorder/MenuBar.swift
@@ -66,6 +66,7 @@ final class MenuBarController: NSObject, ObservableObject {
         let recordingTitle = recorder.isRecording ? "Stop Recording" : "Start Recording"
         let recordingItem = NSMenuItem(title: recordingTitle, action: #selector(toggleRecording), keyEquivalent: "")
         recordingItem.target = self
+        recordingItem.isEnabled = !recorder.isReplaying
         menu.addItem(recordingItem)
 
         let playbackTitle = replayer.isReplaying ? "Stop Playback" : "Replay Latest Macro"
@@ -116,16 +117,17 @@ final class MenuBarController: NSObject, ObservableObject {
     }
 
     @objc private func togglePlayback() {
-        if replayer.isReplaying {
-            replayer.stop()
-        } else if let macro = macroManager.mostRecentMacro {
-            replayer.replay(macro)
-        }
+        replayer.togglePlayback()
     }
 
     @objc private func openMainWindow() {
         NSApp.activate(ignoringOtherApps: true)
-        if let window = NSApp.windows.first(where: { $0.isVisible }) {
+        let visibleWindows = NSApp.windows.filter { $0.isVisible && $0.canBecomeKey }
+        if visibleWindows.isEmpty {
+            NSApp.sendAction(#selector(NSApplication.showAllWindows), to: nil, from: nil)
+        }
+        let windowsToShow = visibleWindows.isEmpty ? NSApp.windows : visibleWindows
+        for window in windowsToShow where window.canBecomeKey {
             window.makeKeyAndOrderFront(nil)
         }
     }

--- a/MacroRecorder/MacroRecorder/Recorder.swift
+++ b/MacroRecorder/MacroRecorder/Recorder.swift
@@ -142,11 +142,12 @@ final class Recorder: ObservableObject {
     }
 
     func toggleRecording() {
+        guard !isReplaying else { return }
         isRecording ? stopRecording() : startRecording()
     }
 
     func startRecording() {
-        guard !isRecording else { return }
+        guard !isRecording, !isReplaying else { return }
         guard ensureAccessibilityPermission() else {
             DispatchQueue.main.async {
                 self.status = .permissionDenied

--- a/MacroRecorder/MacroRecorder/Replayer.swift
+++ b/MacroRecorder/MacroRecorder/Replayer.swift
@@ -64,6 +64,14 @@ final class Replayer: ObservableObject {
         replay(macro)
     }
 
+    func togglePlayback() {
+        if isReplaying {
+            stop()
+        } else {
+            replayMostRecentMacro()
+        }
+    }
+
     func stop() {
         guard isReplaying else { return }
         shouldCancelPlayback = true
@@ -73,7 +81,7 @@ final class Replayer: ObservableObject {
         let modifiers = UInt32(cmdKey | optionKey)
         playbackHotKey = HotKeyCenter.shared.register(keyCode: UInt32(kVK_ANSI_P), modifiers: modifiers) { [weak self] in
             DispatchQueue.main.async {
-                self?.replayMostRecentMacro()
+                self?.togglePlayback()
             }
         }
     }


### PR DESCRIPTION
## Summary
- prevent starting a new recording while a replay is active and provide a playback toggle helper
- refine the menu bar commands to disable conflicting actions and reliably reopen the main window
- update the SwiftUI controls to surface the stop-playback state with appropriate styling

## Testing
- Not run (requires macOS)


------
https://chatgpt.com/codex/tasks/task_e_68dac85ef2788329b670cb8ef405fa21