### PR TITLE
Add GitHub Action to build macOS DMG

### DIFF
--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -1,0 +1,57 @@
+name: Build macOS DMG
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Select Xcode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Build release archive
+        run: |
+          set -euo pipefail
+          xcodebuild \
+            -project Recurra/Recurra.xcodeproj \
+            -scheme Recurra \
+            -configuration Release \
+            -derivedDataPath build \
+            clean build
+
+      - name: Install create-dmg
+        run: brew install create-dmg
+
+      - name: Create DMG
+        run: |
+          set -euo pipefail
+          APP_PATH="build/Build/Products/Release/Recurra.app"
+          if [ ! -d "$APP_PATH" ]; then
+            echo "App bundle not found at $APP_PATH" >&2
+            exit 1
+          fi
+          mkdir -p artifacts
+          create-dmg \
+            --volname "Recurra" \
+            --window-pos 200 120 \
+            --window-size 600 400 \
+            --icon-size 128 \
+            --app-drop-link 425 120 \
+            artifacts/Recurra.dmg \
+            "$APP_PATH"
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Recurra-dmg
+          path: artifacts/Recurra.dmg
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build the Recurra app in release configuration
- package the built app into a DMG using create-dmg and upload it as an artifact

## Testing
- not run (workflow only)


------
https://chatgpt.com/codex/tasks/task_e_68daf4b28c448329bcee8b9b22b58432