### PR TITLE
Improve accessibility permission flow and macOS 13 UI

### DIFF
--- a/Recurra/Recurra/AccessibilityPermission.swift
+++ b/Recurra/Recurra/AccessibilityPermission.swift
@@ -1,0 +1,17 @@
+import ApplicationServices
+
+enum AccessibilityPermission {
+    private static let promptOptionKey = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
+
+    @discardableResult
+    static func ensureTrusted(promptsIfNeeded: Bool = true) -> Bool {
+        if AXIsProcessTrusted() {
+            return true
+        }
+        guard promptsIfNeeded else {
+            return false
+        }
+        let options: CFDictionary = [promptOptionKey: true] as CFDictionary
+        return AXIsProcessTrustedWithOptions(options)
+    }
+}

--- a/Recurra/Recurra/MainView.swift
+++ b/Recurra/Recurra/MainView.swift
@@ -58,9 +58,8 @@ struct MainView: View {
 
             List(selection: $selectedMacroID) {
                 if macroManager.macros.isEmpty {
-                    ContentUnavailableView("No recordings yet",
-                                           systemImage: "square.and.pencil",
-                                           description: Text("Record a macro to see it listed here."))
+                    EmptyMacroPlaceholder()
+                        .listRowSeparator(.hidden)
                         .listRowBackground(Color.clear)
                 } else {
                     ForEach(macroManager.macros) { macro in
@@ -220,6 +219,33 @@ struct MainView: View {
 }
 
 // MARK: - Subviews
+
+private struct EmptyMacroPlaceholder: View {
+    var body: some View {
+        Group {
+            if #available(macOS 14.0, *) {
+                ContentUnavailableView("No recordings yet",
+                                       systemImage: "square.and.pencil",
+                                       description: Text("Record a macro to see it listed here."))
+            } else {
+                VStack(spacing: 8) {
+                    Image(systemName: "square.and.pencil")
+                        .font(.system(size: 36, weight: .regular))
+                        .foregroundStyle(.secondary)
+                    Text("No recordings yet")
+                        .font(.title3.weight(.semibold))
+                    Text("Record a macro to see it listed here.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: 220)
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, 36)
+            }
+        }
+    }
+}
 
 private struct MacroRow: View {
     let macro: RecordedMacro

--- a/Recurra/Recurra/Recorder.swift
+++ b/Recurra/Recurra/Recorder.swift
@@ -148,7 +148,7 @@ final class Recorder: ObservableObject {
 
     func startRecording() {
         guard !isRecording, !isReplaying else { return }
-        guard ensureAccessibilityPermission() else {
+        guard AccessibilityPermission.ensureTrusted() else {
             DispatchQueue.main.async {
                 self.status = .permissionDenied
             }
@@ -253,14 +253,6 @@ final class Recorder: ObservableObject {
         DispatchQueue.main.async {
             self.status = .permissionDenied
         }
-    }
-
-    private func ensureAccessibilityPermission() -> Bool {
-        if AXIsProcessTrusted() {
-            return true
-        }
-        let prompt: CFDictionary = [kAXTrustedCheckOptionPrompt.takeRetainedValue() as String: true] as CFDictionary
-        return AXIsProcessTrustedWithOptions(prompt)
     }
 
     private func handleIncoming(event: CGEvent, type: CGEventType) -> Unmanaged<CGEvent> {

--- a/Recurra/Recurra/Replayer.swift
+++ b/Recurra/Recurra/Replayer.swift
@@ -23,16 +23,11 @@ final class Replayer: ObservableObject {
         HotKeyCenter.shared.unregister(identifier: playbackHotKey)
     }
 
-    func attach(recorder: Recorder) {
-        self.recorder = recorder
-    }
-
     func replay(_ macro: RecordedMacro) {
         guard !isReplaying else { return }
         guard recorder?.isRecording == false else { return }
         guard !macro.events.isEmpty else { return }
-        let prompt: CFDictionary = [kAXTrustedCheckOptionPrompt.takeRetainedValue() as String: true] as CFDictionary
-        guard AXIsProcessTrusted() || AXIsProcessTrustedWithOptions(prompt) else {
+        guard AccessibilityPermission.ensureTrusted() else {
             recorder?.markPermissionDenied()
             return
         }


### PR DESCRIPTION
## Summary
- add an AccessibilityPermission helper to centralize the trusted prompt setup and avoid repeated unmanaged lookups
- update the recorder and replayer to use the shared helper and drop the unused attach hook
- replace the macOS 14-only ContentUnavailableView with a custom placeholder so the UI also builds on macOS 13

## Testing
- swift build *(fails: Package.swift is not present in this project)*

------
https://chatgpt.com/codex/tasks/task_e_68daf980055083299478fd379feb9039