### PR TITLE
Add persistent macro storage and permission messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A lightweight SwiftUI macro recorder for macOS that captures keyboard and mouse 
 - ⌨️ High-fidelity recording of keyboard and mouse events backed by Accessibility permissions.
 - ▶️ Smooth, cancellable playback with safe timing across the entire macro.
 - 📁 Macro library with rename, delete, and replay actions plus customizable default names.
+- 💾 Persistent macro storage backed by Application Support serialization.
 - 🔑 Global hotkeys for record (`⌘⌥R`) and replay (`⌘⌥P`).
 - ♿ Text-based onboarding to request Accessibility permissions when required.
 
@@ -52,7 +53,6 @@ Recurra/
 ## Known Limitations
 
 - Some games and secure apps block synthetic events, so playback may be ignored.
-- Macros are stored for the current session; persisting them between launches is on the roadmap.
 - Background recording is paused if the system revokes the Accessibility permission.
 
 ## Roadmap
@@ -62,7 +62,7 @@ Recurra/
 | ✅ | Menu bar controls and SwiftUI command menu |
 | ✅ | In-app macro library with rename/delete |
 | ✅ | Global hotkeys for record & replay |
-| ⏳ | Persistent macro storage using on-disk serialization |
+| ✅ | Persistent macro storage using on-disk serialization |
 | ⏳ | Timeline editor to tweak delays |
 | ⏳ | Sharing/export support |
 

--- a/Recurra/Recurra/Info.plist
+++ b/Recurra/Recurra/Info.plist
@@ -22,6 +22,8 @@
     <string>13.0</string>
     <key>NSAppleEventsUsageDescription</key>
     <string>This app requires permission to control your Mac in order to replay recorded actions.</string>
+    <key>NSAccessibilityUsageDescription</key>
+    <string>Recurra needs Accessibility access to observe and replay input events as macros.</string>
     <key>NSInputMonitoringUsageDescription</key>
     <string>This app records keyboard and mouse input to build macros for playback.</string>
     <key>NSPrincipalClass</key>

--- a/Recurra/Recurra/MacroManager.swift
+++ b/Recurra/Recurra/MacroManager.swift
@@ -18,38 +18,47 @@ struct RecordedMacro: Identifiable {
 final class MacroManager: ObservableObject {
     @Published private(set) var macros: [RecordedMacro] = []
 
+    private let fileManager: FileManager
+    private let persistenceURL: URL
+    private let persistenceQueue = DispatchQueue(label: "com.recurra.persistence", qos: .utility)
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+        self.persistenceURL = MacroManager.makePersistenceURL(fileManager: fileManager)
+        loadPersistedMacros()
+    }
+
     var mostRecentMacro: RecordedMacro? {
         macros.first
     }
 
     func add(_ macro: RecordedMacro) {
-        if Thread.isMainThread {
-            macros.insert(macro, at: 0)
-        } else {
-            DispatchQueue.main.async {
-                self.macros.insert(macro, at: 0)
-            }
+        let insert = {
+            self.macros.insert(macro, at: 0)
+            self.persistCurrentState()
         }
+
+        executeOnMain(insert)
     }
 
     func remove(_ macro: RecordedMacro) {
-        if Thread.isMainThread {
-            macros.removeAll { $0.id == macro.id }
-        } else {
-            DispatchQueue.main.async {
-                self.macros.removeAll { $0.id == macro.id }
-            }
+        let removal = {
+            self.macros.removeAll { $0.id == macro.id }
+            self.persistCurrentState()
         }
+
+        executeOnMain(removal)
     }
 
     func remove(at offsets: IndexSet) {
-        if Thread.isMainThread {
-            macros.remove(atOffsets: offsets)
-        } else {
-            DispatchQueue.main.async {
-                self.macros.remove(atOffsets: offsets)
+        let removal = {
+            for index in offsets.sorted(by: >) {
+                self.macros.remove(at: index)
             }
+            self.persistCurrentState()
         }
+
+        executeOnMain(removal)
     }
 
     func rename(_ macro: RecordedMacro, to newName: String) {
@@ -59,17 +68,122 @@ final class MacroManager: ObservableObject {
         let update = {
             guard let index = self.macros.firstIndex(where: { $0.id == macro.id }) else { return }
             self.macros[index].name = trimmed
+            self.persistCurrentState()
         }
 
-        if Thread.isMainThread {
-            update()
-        } else {
-            DispatchQueue.main.async(execute: update)
-        }
+        executeOnMain(update)
     }
 
     func macro(with id: RecordedMacro.ID?) -> RecordedMacro? {
         guard let id else { return nil }
         return macros.first(where: { $0.id == id })
+    }
+
+    private func executeOnMain(_ block: @escaping () -> Void) {
+        if Thread.isMainThread {
+            block()
+        } else {
+            DispatchQueue.main.async(execute: block)
+        }
+    }
+
+    private func loadPersistedMacros() {
+        persistenceQueue.async {
+            guard let data = try? Data(contentsOf: self.persistenceURL) else { return }
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            do {
+                let storedMacros = try decoder.decode([StoredMacro].self, from: data)
+                let macros = storedMacros.compactMap { $0.makeRecordedMacro() }
+                DispatchQueue.main.async {
+                    self.macros = macros
+                }
+            } catch {
+                NSLog("Failed to decode macros: %@", error.localizedDescription)
+            }
+        }
+    }
+
+    private func persistCurrentState() {
+        let snapshot = macros
+        persistenceQueue.async {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            let stored = snapshot.compactMap { StoredMacro(macro: $0) }
+            do {
+                let data = try encoder.encode(stored)
+                try self.ensurePersistenceDirectoryExists()
+                try data.write(to: self.persistenceURL, options: .atomic)
+            } catch {
+                NSLog("Failed to persist macros: %@", error.localizedDescription)
+            }
+        }
+    }
+
+    private func ensurePersistenceDirectoryExists() throws {
+        let directory = persistenceURL.deletingLastPathComponent()
+        if !fileManager.fileExists(atPath: directory.path) {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+    }
+
+    private static func makePersistenceURL(fileManager: FileManager) -> URL {
+        let baseDirectory: URL
+        if let support = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first {
+            baseDirectory = support
+        } else {
+            baseDirectory = fileManager.homeDirectoryForCurrentUser.appendingPathComponent("Library/Application Support", isDirectory: true)
+        }
+        return baseDirectory
+            .appendingPathComponent("Recurra", isDirectory: true)
+            .appendingPathComponent("macros.json", isDirectory: false)
+    }
+}
+
+// MARK: - Persistence Helpers
+
+private struct StoredMacro: Codable {
+    struct StoredEvent: Codable {
+        let delay: TimeInterval
+        let data: Data
+    }
+
+    let id: UUID
+    let name: String
+    let createdAt: Date
+    let duration: TimeInterval
+    let events: [StoredEvent]
+
+    init?(macro: RecordedMacro) {
+        let events = macro.events.compactMap { event -> StoredEvent? in
+            guard let data = event.event.archivedData() else { return nil }
+            return StoredEvent(delay: event.delay, data: data)
+        }
+        guard events.count == macro.events.count else { return nil }
+        self.id = macro.id
+        self.name = macro.name
+        self.createdAt = macro.createdAt
+        self.duration = macro.duration
+        self.events = events
+    }
+
+    func makeRecordedMacro() -> RecordedMacro? {
+        let events = events.compactMap { stored -> RecordedMacro.TimedEvent? in
+            guard let event = CGEvent.fromArchivedData(stored.data) else { return nil }
+            return RecordedMacro.TimedEvent(delay: stored.delay, event: event)
+        }
+        guard events.count == self.events.count else { return nil }
+        return RecordedMacro(id: id, name: name, createdAt: createdAt, events: events, duration: duration)
+    }
+}
+
+private extension CGEvent {
+    func archivedData() -> Data? {
+        guard let data = CGEventCreateData(nil, self) else { return nil }
+        return data as Data
+    }
+
+    static func fromArchivedData(_ data: Data) -> CGEvent? {
+        CGEventCreateFromData(nil, data as CFData)
     }
 }


### PR DESCRIPTION
## Summary
- add Application Support persistence for recorded macros with CGEvent serialization
- keep recorder naming in sync with persisted macros and observe library updates
- include Accessibility usage copy in Info.plist and update README to note persistence

## Testing
- not run (requires macOS environment)

------
https://chatgpt.com/codex/tasks/task_e_68db08861d3c8329823b1f45d022aebb