### PR TITLE
Add GitHub Actions workflow to build macOS DMG

### DIFF
--- a/.github/workflows/build-macos-dmg.yml
+++ b/.github/workflows/build-macos-dmg.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Select Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '15.2'
+          xcode-version: '16.2'
 
       - name: Build Release app
         run: |

--- a/.github/workflows/build-macos-dmg.yml
+++ b/.github/workflows/build-macos-dmg.yml
@@ -1,0 +1,51 @@
+name: macOS DMG Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.2'
+
+      - name: Build Release app
+        run: |
+          set -eo pipefail
+          xcodebuild \
+            -project Recurra/Recurra.xcodeproj \
+            -scheme Recurra \
+            -configuration Release \
+            -derivedDataPath build \
+            clean build
+        env:
+          NSUnbufferedIO: 'YES'
+
+      - name: Create DMG
+        run: |
+          set -euo pipefail
+          APP_PATH="build/Build/Products/Release/Recurra.app"
+          STAGING="build/dmg-staging"
+          mkdir -p "$STAGING"
+          cp -R "$APP_PATH" "$STAGING/"
+          hdiutil create \
+            -volname "Recurra" \
+            -srcfolder "$STAGING" \
+            -ov \
+            -format UDZO \
+            build/Recurra.dmg
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Recurra.dmg
+          path: build/Recurra.dmg

--- a/.github/workflows/build-macos-dmg.yml
+++ b/.github/workflows/build-macos-dmg.yml
@@ -25,7 +25,11 @@ jobs:
             -project Recurra/Recurra.xcodeproj \
             -scheme Recurra \
             -configuration Release \
+            -destination 'platform=macOS' \
             -derivedDataPath build \
+            CODE_SIGNING_ALLOWED=NO \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY='' \
             clean build
         env:
           NSUnbufferedIO: 'YES'


### PR DESCRIPTION
## Summary
- add a macOS GitHub Actions workflow that builds the Recurra app in Release configuration
- package the compiled app into a compressed DMG and upload it as a workflow artifact

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68db0ad3c9748329976ae7a5b5b0bc12